### PR TITLE
Deleteing files now complies with api v2.1

### DIFF
--- a/app/src/main/java/com/theta360/pluginapplication/network/HttpConnector.java
+++ b/app/src/main/java/com/theta360/pluginapplication/network/HttpConnector.java
@@ -47,6 +47,7 @@ public class HttpConnector {
     private String mFingerPrint = null;
     private Timer mCheckStatusTimer = null;
     private HttpEventListener mHttpEventListener = null;
+    private HttpDeleteFileListener mHttpDeleteFileListener = null;
 
     /**
      * Constructor
@@ -562,13 +563,25 @@ public class HttpConnector {
         return is;
     }
 
-    /**
-     * Delete specified file
+	/**
+	 * Delete specified file
+	 *
+	 * @param deletedFileId File ID
+	 * @param listener Listener for receiving deletion results
+	 */
+	public void deleteFile(String deletedFileId, HttpDeleteFileListener listener) {
+		ArrayList<String> fileIds = new ArrayList<>();
+		fileIds.add(deletedFileId);
+		deleteFiles(fileIds, listener);
+	}
+
+	/**
+     * Delete specified files
      *
-     * @param deletedFileId File ID
+     * @param deletedFileIds File ID's
      * @param listener Listener for receiving deletion results
      */
-    public void deleteFile(String deletedFileId, HttpEventListener listener) {
+    public void deleteFiles(ArrayList<String> deletedFileIds, HttpDeleteFileListener listener) {
 
         // set capture mode to image
         String errorMessage = setImageCaptureMode();
@@ -580,14 +593,21 @@ public class HttpConnector {
         HttpURLConnection postConnection = createHttpConnection("POST", "/osc/commands/execute");
         JSONObject input = new JSONObject();
         String responseData;
-        mHttpEventListener = listener;
+        mHttpDeleteFileListener = listener;
         InputStream is = null;
 
         try {
             // send HTTP POST
             input.put("name", "camera.delete");
             JSONObject parameters = new JSONObject();
-            parameters.put("fileUri", deletedFileId);
+            JSONArray fileIdArray = new JSONArray();
+
+            for(String fileId : deletedFileIds){
+            	fileIdArray.put(fileId);
+			}
+
+            parameters.put("fileUrls", fileIdArray);
+
             input.put("parameters", parameters);
 
             OutputStream os = postConnection.getOutputStream();
@@ -603,16 +623,16 @@ public class HttpConnector {
             JSONObject output = new JSONObject(responseData);
             String status = output.getString("state");
 
+
             if (status.equals("inProgress")) {
                 getState();
                 mCheckStatusTimer = new Timer(true);
-                DeletedTimerTask deletedTimerTask = new DeletedTimerTask();
-                deletedTimerTask.setDeletedFileId(deletedFileId);
+                DeletedTimerTask deletedTimerTask = new DeletedTimerTask(deletedFileIds);
                 mCheckStatusTimer.scheduleAtFixedRate(deletedTimerTask, CHECK_STATUS_PERIOD_MS,
                         CHECK_STATUS_PERIOD_MS);
             } else if (status.equals("done")) {
-                mHttpEventListener.onObjectChanged(deletedFileId);
-                mHttpEventListener.onCompleted();
+                mHttpDeleteFileListener.onObjectChanged(deletedFileIds);
+                mHttpDeleteFileListener.onCompleted();
                 mFingerPrint = null;
             }
         } catch (IOException e) {
@@ -1026,21 +1046,22 @@ public class HttpConnector {
      * Status check class for file deletion
      */
     private class DeletedTimerTask extends TimerTask {
-        private String mDeletedFileId = null;
+        private final ArrayList<String> deleteFileIds;
 
-        public void setDeletedFileId(String deletedFileId) {
-            mDeletedFileId = deletedFileId;
-        }
+		private DeletedTimerTask(ArrayList<String> deleteFileIds) {
+			this.deleteFileIds = deleteFileIds;
+		}
 
-        @Override
+
+		@Override
         public void run() {
             boolean update = isUpdate();
             mHttpEventListener.onCheckStatus(update);
             if (update) {
                 mCheckStatusTimer.cancel();
                 getState();
-                mHttpEventListener.onObjectChanged(mDeletedFileId);
-                mHttpEventListener.onCompleted();
+                mHttpDeleteFileListener.onObjectChanged(deleteFileIds);
+                mHttpDeleteFileListener.onCompleted();
                 mFingerPrint = null;
             }
         }

--- a/app/src/main/java/com/theta360/pluginapplication/network/HttpDeleteFileListener.java
+++ b/app/src/main/java/com/theta360/pluginapplication/network/HttpDeleteFileListener.java
@@ -1,0 +1,33 @@
+package com.theta360.pluginapplication.network;
+
+import java.util.ArrayList;
+
+/**
+ * Created by traybould on 3/12/2019.
+ */
+
+public interface HttpDeleteFileListener {
+
+	/**
+	 * Notifies you of the device status check results
+	 * @param newStatus true:Update available, false;No update available
+	 */
+	void onCheckStatus(boolean newStatus);
+
+	/**
+	 * Notifies you when the files are deleted
+	 * @param deletedImages Urls of images that were deleted
+	 * */
+	void onObjectChanged(ArrayList<String> deletedImages);
+
+	/**
+	 * Notify on completion of event
+	 */
+	void onCompleted();
+
+	/**
+	 * Notify in the event of an error
+	 */
+	void onError(String errorMessage);
+
+}


### PR DESCRIPTION
The HttpConnector class is still using the old v2.0 web api for the camera, for deleting images, and does not currently work this way. This commit changes the HttpConnector logic so that it can delete files off the camera using the v2.1 web api. This requires a different callback with an array of multiple image paths which I have created "HttpDeleteFileListener". 

https://developers.theta360.com/en/docs/v2.1/api_reference/commands/camera.delete.html