### PR TITLE
Deleteing files now complies with api v2.1

### DIFF
--- a/app/src/main/java/com/theta360/pluginapplication/network/HttpDeleteFileListener.java
+++ b/app/src/main/java/com/theta360/pluginapplication/network/HttpDeleteFileListener.java
@@ -1,0 +1,29 @@
+package com.theta360.pluginapplication.network;
+
+import java.util.ArrayList;
+
+public interface HttpDeleteFileListener {
+
+	/**
+	 * Notifies you of the device status check results
+	 * @param newStatus true:Update available, false;No update available
+	 */
+	void onCheckStatus(boolean newStatus);
+
+	/**
+	 * Notifies you when the files are deleted
+	 * @param deletedImages Urls of images that were deleted
+	 * */
+	void onObjectChanged(ArrayList<String> deletedImages);
+
+	/**
+	 * Notify on completion of event
+	 */
+	void onCompleted();
+
+	/**
+	 * Notify in the event of an error
+	 */
+	void onError(String errorMessage);
+
+}


### PR DESCRIPTION
The HttpConnector class is still using the old v2.0 web api for the camera, for deleting images, and does not currently work this way. This commit changes the HttpConnector logic so that it can delete files off the camera using the v2.1 web api. This requires a different callback with an array of multiple image paths which I have created "HttpDeleteFileListener".

https://developers.theta360.com/en/docs/v2.1/api_reference/commands/camera.delete.html