### PR TITLE
Replace javadoc-style with regular block-style.

### DIFF
--- a/app/src/main/java/com/theta360/pluginapplication/MainActivity.java
+++ b/app/src/main/java/com/theta360/pluginapplication/MainActivity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +56,7 @@ public class MainActivity extends PluginActivity {
 
             @Override
             public void onKeyUp(int keyCode, KeyEvent event) {
-                /**
+                /*
                  * You can control the LED of the camera.
                  * It is possible to change the way of lighting, the cycle of blinking, the color of light emission.
                  * Light emitting color can be changed only LED3.

--- a/app/src/main/java/com/theta360/pluginapplication/model/Constants.java
+++ b/app/src/main/java/com/theta360/pluginapplication/model/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/model/ImageSize.java
+++ b/app/src/main/java/com/theta360/pluginapplication/model/ImageSize.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/model/Photo.java
+++ b/app/src/main/java/com/theta360/pluginapplication/model/Photo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/model/RotateInertia.java
+++ b/app/src/main/java/com/theta360/pluginapplication/model/RotateInertia.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/model/package-info.java
+++ b/app/src/main/java/com/theta360/pluginapplication/model/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/network/DeviceInfo.java
+++ b/app/src/main/java/com/theta360/pluginapplication/network/DeviceInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/network/HttpConnector.java
+++ b/app/src/main/java/com/theta360/pluginapplication/network/HttpConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/network/HttpDownloadListener.java
+++ b/app/src/main/java/com/theta360/pluginapplication/network/HttpDownloadListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/network/HttpEventListener.java
+++ b/app/src/main/java/com/theta360/pluginapplication/network/HttpEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/network/ImageData.java
+++ b/app/src/main/java/com/theta360/pluginapplication/network/ImageData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/network/ImageInfo.java
+++ b/app/src/main/java/com/theta360/pluginapplication/network/ImageInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/network/StorageInfo.java
+++ b/app/src/main/java/com/theta360/pluginapplication/network/StorageInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/network/XMP.java
+++ b/app/src/main/java/com/theta360/pluginapplication/network/XMP.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/network/package-info.java
+++ b/app/src/main/java/com/theta360/pluginapplication/network/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/src/main/java/com/theta360/pluginapplication/task/TakePictureTask.java
+++ b/app/src/main/java/com/theta360/pluginapplication/task/TakePictureTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The copyright notice was written as a javadoc-style comment. However, the copyright notice is not a Javadoc. Therefore, I replaced javadoc-style comments with regular block-style comments.